### PR TITLE
Enhance voice UX with speaking indicators and audio preferences

### DIFF
--- a/web/src/components/settings-panel.tsx
+++ b/web/src/components/settings-panel.tsx
@@ -180,6 +180,76 @@ export function SettingsPanel(props: SettingsPanelProps) {
           </label>
         </article>
 
+
+
+        <article className="setting-card">
+          <h3>Voice & Audio</h3>
+
+          <label className="field-stack">
+            <span>
+              <strong>Input sensitivity</strong>
+              <small>Lower values react faster to quieter voices.</small>
+            </span>
+            <input
+              type="range"
+              min={0.005}
+              max={0.12}
+              step={0.005}
+              value={props.preferences.voiceInputSensitivity}
+              onChange={(event) =>
+                props.onUpdatePreferences({ voiceInputSensitivity: Number(event.target.value) })
+              }
+            />
+            <small>{props.preferences.voiceInputSensitivity.toFixed(3)}</small>
+          </label>
+
+          <label className="field-stack">
+            <span>
+              <strong>Output volume</strong>
+              <small>Applies to all incoming voice streams.</small>
+            </span>
+            <input
+              type="range"
+              min={0}
+              max={200}
+              step={5}
+              value={props.preferences.voiceOutputVolume}
+              onChange={(event) =>
+                props.onUpdatePreferences({ voiceOutputVolume: Number(event.target.value) })
+              }
+            />
+            <small>{props.preferences.voiceOutputVolume}%</small>
+          </label>
+
+          <label className="toggle-row">
+            <input
+              type="checkbox"
+              checked={props.preferences.showVoiceActivity}
+              onChange={(event) =>
+                props.onUpdatePreferences({ showVoiceActivity: event.target.checked })
+              }
+            />
+            <span>
+              <strong>Show speaking indicators</strong>
+              <small>Highlight users while they are actively speaking.</small>
+            </span>
+          </label>
+
+          <label className="toggle-row">
+            <input
+              type="checkbox"
+              checked={props.preferences.autoMuteOnJoin}
+              onChange={(event) =>
+                props.onUpdatePreferences({ autoMuteOnJoin: event.target.checked })
+              }
+            />
+            <span>
+              <strong>Join voice muted</strong>
+              <small>Keep microphone muted until you explicitly unmute.</small>
+            </span>
+          </label>
+        </article>
+
         <article className="setting-card">
           <h3>Notifications & Shortcuts</h3>
           <p>

--- a/web/src/hooks/use-user-preferences.ts
+++ b/web/src/hooks/use-user-preferences.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import type { UserPreferences } from '../types/preferences';
 import { DEFAULT_USER_PREFERENCES } from '../types/preferences';
 
-const PREFS_KEY = 'discordclone_user_preferences_v2';
+const PREFS_KEY = 'discordclone_user_preferences_v3';
 
 function parsePreferences(raw: string | null): UserPreferences {
   if (!raw) {
@@ -24,6 +24,22 @@ function parsePreferences(raw: string | null): UserPreferences {
           ? parsed.enterToSend
           : DEFAULT_USER_PREFERENCES.enterToSend,
       playMessageSound: Boolean(parsed.playMessageSound),
+      voiceInputSensitivity:
+        typeof parsed.voiceInputSensitivity === 'number'
+          ? Math.min(0.12, Math.max(0.005, parsed.voiceInputSensitivity))
+          : DEFAULT_USER_PREFERENCES.voiceInputSensitivity,
+      voiceOutputVolume:
+        typeof parsed.voiceOutputVolume === 'number'
+          ? Math.min(200, Math.max(0, Math.round(parsed.voiceOutputVolume)))
+          : DEFAULT_USER_PREFERENCES.voiceOutputVolume,
+      showVoiceActivity:
+        typeof parsed.showVoiceActivity === 'boolean'
+          ? parsed.showVoiceActivity
+          : DEFAULT_USER_PREFERENCES.showVoiceActivity,
+      autoMuteOnJoin:
+        typeof parsed.autoMuteOnJoin === 'boolean'
+          ? parsed.autoMuteOnJoin
+          : DEFAULT_USER_PREFERENCES.autoMuteOnJoin,
     };
   } catch {
     return DEFAULT_USER_PREFERENCES;

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -881,6 +881,35 @@ button {
   font-size: 11px;
 }
 
+
+.voice-panel-header-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.voice-participant-item.speaking {
+  border-color: rgba(88, 101, 242, 0.65);
+  box-shadow: inset 0 0 0 1px rgba(88, 101, 242, 0.3);
+  background: linear-gradient(90deg, rgba(88, 101, 242, 0.14), rgba(88, 101, 242, 0.02));
+}
+
+.voice-speaking-dot {
+  width: 8px;
+  height: 8px;
+  margin-left: 8px;
+  border-radius: 999px;
+  display: inline-block;
+  border: 1px solid var(--panel-border);
+  background: transparent;
+}
+
+.voice-speaking-dot.active {
+  border-color: rgba(35, 165, 89, 0.5);
+  background: #23a559;
+  box-shadow: 0 0 0 3px rgba(35, 165, 89, 0.16);
+}
+
 .voice-audio-sinks {
   width: 0;
   height: 0;
@@ -937,6 +966,26 @@ button {
   gap: 12px;
   align-items: center;
   margin: 10px 0 14px;
+}
+
+.field-stack {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.field-stack span {
+  display: grid;
+  gap: 3px;
+}
+
+.field-stack input[type='range'] {
+  width: 100%;
+}
+
+.field-stack small {
+  color: var(--text-muted);
+  font-size: 12px;
 }
 
 .field-inline span {

--- a/web/src/types/preferences.ts
+++ b/web/src/types/preferences.ts
@@ -8,6 +8,10 @@ export interface UserPreferences {
   fontScale: FontScale;
   enterToSend: boolean;
   playMessageSound: boolean;
+  voiceInputSensitivity: number;
+  voiceOutputVolume: number;
+  showVoiceActivity: boolean;
+  autoMuteOnJoin: boolean;
 }
 
 export const DEFAULT_USER_PREFERENCES: UserPreferences = {
@@ -18,4 +22,8 @@ export const DEFAULT_USER_PREFERENCES: UserPreferences = {
   fontScale: 'md',
   enterToSend: true,
   playMessageSound: false,
+  voiceInputSensitivity: 0.04,
+  voiceOutputVolume: 100,
+  showVoiceActivity: true,
+  autoMuteOnJoin: false,
 };


### PR DESCRIPTION
### Motivation
- Improve in-app voice UX to match modern expectations (show who is speaking, per-user audio settings, mute controls) while preserving the project's Refined Brutalist visual language. 
- Give users configurable controls for input sensitivity, per‑sink output volume, speaking indicators and auto‑mute behavior to reduce friction when joining voice channels.

### Description
- Persisted new preferences in `UserPreferences`: `voiceInputSensitivity`, `voiceOutputVolume`, `showVoiceActivity`, and `autoMuteOnJoin` with defaults in `web/src/types/preferences.ts` and handling in `web/src/hooks/use-user-preferences.ts`.
- Added a `Voice & Audio` settings card in `web/src/components/settings-panel.tsx` exposing sliders and toggles to control sensitivity, output volume, speaking indicators, and join-muted behavior.
- Reworked `web/src/components/voice-channel-panel.tsx` to include a mic mute/unmute control, speaking badges, per‑participant speaking highlights and clearer status labels (e.g. `You (Muted)`, `Speaking`).
- Implemented client-side voice features in `web/src/pages/chat-page.tsx`: local mic mute state, auto‑mute on join, Web Audio `AnalyserNode` RMS‑based speaking detection (configurable by `voiceInputSensitivity`), and applying `voiceOutputVolume` to remote `<audio>` sinks.
- Added CSS for the new controls and speaking indicators in `web/src/styles/global.css` while keeping the existing style tokens and layout conventions.

### Testing
- Built the frontend with `npm run -w web build`, which completed successfully. 
- Attempted to start the backend (`npm run -w backend dev`) but the local environment failed due to an unrelated `@prisma/client` export mismatch, not caused by these UI changes. 
- A headless browser screenshot attempt via Playwright timed out / crashed (Chromium SIGSEGV) in this environment so visual screenshot validation was not produced here. 
- No destructive database operations or migrations were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d36283f408325a2ce6bd4f119937c)