### PR TITLE
Add inline message reaction picker UI

### DIFF
--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -2979,6 +2979,10 @@ body.font-scale-lg {
     right: -46px;
   }
 
+  .message-reaction-popover {
+    right: -46px;
+  }
+
   .settings-toolbar {
     flex-direction: column;
     align-items: flex-start;
@@ -3208,6 +3212,26 @@ body.font-scale-lg {
 .toolbar-actions {
   display: flex;
   gap: 2px;
+}
+
+.message-reaction-picker {
+  position: relative;
+}
+
+.message-reaction-popover {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 6px);
+  width: 214px;
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  background-color: #1b1d22;
+  padding: 8px;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 6px;
+  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.45);
+  z-index: 16;
 }
 
 .toolbar-btn {


### PR DESCRIPTION
Introduce an inline reaction picker for messages: add MESSAGE_REACTION_PANEL_EMOJIS, refs/state (reactionPickerRef, reactionPickerMessageId), and compute messageReactionPanelEmojis by merging recentEmojis with defaults. Add event handlers to close the picker on outside click, scroll, or Escape and clear the picker on channel change or when opening the context menu. Replace the previous toolbar reaction button with a reaction picker button that toggles a popover of emoji buttons; clicking an emoji calls onToggleReaction, records the emoji via addRecentEmoji, and closes the picker. Remove redundant quick-reaction buttons from the message context menu. Add corresponding CSS (.message-reaction-picker and .message-reaction-popover) for layout, positioning, and styling.