### PR TITLE
Add server management UI and member listing API

### DIFF
--- a/backend/src/repositories/server.repository.ts
+++ b/backend/src/repositories/server.repository.ts
@@ -28,6 +28,16 @@ interface ServerMemberPreview {
   user: ServerMemberUserPreview;
 }
 
+interface ServerMemberListUserPreview {
+  id: string;
+  username: string;
+  avatarUrl: string | null;
+}
+
+export interface ServerMemberWithUser extends ServerMember {
+  user: ServerMemberListUserPreview;
+}
+
 export interface ServerWithMembers extends Server {
   owner: ServerOwnerPreview;
   members: ServerMemberPreview[];
@@ -149,6 +159,7 @@ export interface ServerRepository {
   upsertDefault(params: { slug: string; name: string; ownerId: string }): Promise<ServerWithMembers>;
   ensureAllUsersAreMembers(serverId: string): Promise<number>;
   findMember(serverId: string, userId: string): Promise<ServerMember | null>;
+  listMembers(serverId: string): Promise<ServerMemberWithUser[]>;
   ensureMember(params: { serverId: string; userId: string; role?: UserRole }): Promise<ServerMember>;
   createInvite(params: {
     serverId: string;
@@ -321,6 +332,24 @@ export class PrismaServerRepository implements ServerRepository {
         serverId_userId: {
           serverId,
           userId,
+        },
+      },
+    });
+  }
+
+  listMembers(serverId: string): Promise<ServerMemberWithUser[]> {
+    return prisma.serverMember.findMany({
+      where: {
+        serverId,
+      },
+      orderBy: [{ createdAt: 'asc' }],
+      include: {
+        user: {
+          select: {
+            id: true,
+            username: true,
+            avatarUrl: true,
+          },
         },
       },
     });

--- a/backend/src/routes/server.routes.ts
+++ b/backend/src/routes/server.routes.ts
@@ -76,6 +76,19 @@ export const serverRoutes: FastifyPluginAsync<ServerRoutesOptions> = async (fast
   );
 
   fastify.get(
+    '/servers/:serverId/members',
+    {
+      preHandler: [authPreHandler],
+      config: { rateLimit: { max: 120, timeWindow: 60_000 } },
+    },
+    async (request) => {
+      const { serverId } = serverIdParamsSchema.parse(request.params);
+      const members = await options.serverService.listMembers(request.user.userId, serverId);
+      return { members };
+    },
+  );
+
+  fastify.get(
     '/servers/:serverId/analytics',
     {
       preHandler: [authPreHandler],

--- a/backend/src/services/server.service.ts
+++ b/backend/src/services/server.service.ts
@@ -6,6 +6,7 @@ import type {
   ModerationActionWithRelations,
   ServerInviteWithRelations,
   ServerAnalyticsSnapshot,
+  ServerMemberWithUser,
   ServerRepository,
   ServerWithMembers,
 } from '../repositories/server.repository.js';
@@ -15,6 +16,8 @@ import { isPrivilegedRole } from '../utils/roles.js';
 const DEFAULT_SERVER_SLUG = 'harmony-default';
 const DEFAULT_SERVER_NAME = 'Harmony';
 const DEFAULT_GLOBAL_CHANNEL = 'global';
+const DEFAULT_NEW_SERVER_TEXT_CHANNEL = 'general';
+const DEFAULT_NEW_SERVER_VOICE_CHANNEL = 'voice';
 
 export interface ServerSummary {
   id: string;
@@ -85,6 +88,19 @@ export interface ModerationActionSummary {
 
 export interface ServerAnalyticsSummary extends ServerAnalyticsSnapshot {}
 
+export interface ServerMemberSummary {
+  id: string;
+  userId: string;
+  role: UserRole;
+  createdAt: Date;
+  updatedAt: Date;
+  user: {
+    id: string;
+    username: string;
+    avatarUrl: string | null;
+  };
+}
+
 export class ServerService {
   constructor(
     private readonly serverRepo: ServerRepository,
@@ -154,6 +170,21 @@ export class ServerService {
       createdAt: action.createdAt,
       actor: action.actor,
       targetUser: action.targetUser,
+    };
+  }
+
+  private toMemberSummary(member: ServerMemberWithUser): ServerMemberSummary {
+    return {
+      id: member.id,
+      userId: member.userId,
+      role: member.role,
+      createdAt: member.createdAt,
+      updatedAt: member.updatedAt,
+      user: {
+        id: member.user.id,
+        username: member.user.username,
+        avatarUrl: member.user.avatarUrl,
+      },
     };
   }
 
@@ -278,7 +309,29 @@ export class ServerService {
       action: 'server.create',
       metadata: input.metadata,
     });
+
+    await this.channelRepo.ensurePublicByName({
+      name: DEFAULT_NEW_SERVER_TEXT_CHANNEL,
+      serverId: created.id,
+    });
+    const existingVoiceChannel = await this.channelRepo.findByNameInServer({
+      serverId: created.id,
+      name: DEFAULT_NEW_SERVER_VOICE_CHANNEL,
+    });
+    if (!existingVoiceChannel) {
+      await this.channelRepo.createVoice({
+        name: DEFAULT_NEW_SERVER_VOICE_CHANNEL,
+        serverId: created.id,
+      });
+    }
+
     return this.toSummary(created, userId);
+  }
+
+  async listMembers(userId: string, serverId: string): Promise<ServerMemberSummary[]> {
+    await this.assertCanManageServer(serverId, userId);
+    const members = await this.serverRepo.listMembers(serverId);
+    return members.map((member) => this.toMemberSummary(member));
   }
 
   async createInvite(

--- a/backend/tests/server.routes.members.test.ts
+++ b/backend/tests/server.routes.members.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ChannelService } from '../src/services/channel.service.js';
+import type { ServerService } from '../src/services/server.service.js';
+import { serverRoutes } from '../src/routes/server.routes.js';
+
+type RouteHandler = (request: any, reply: any) => Promise<unknown>;
+
+interface CapturedRoute {
+  method: 'GET' | 'POST' | 'DELETE';
+  path: string;
+  options: { preHandler?: unknown[]; config?: unknown };
+  handler: RouteHandler;
+}
+
+async function registerRoutes() {
+  const routes: CapturedRoute[] = [];
+  const listMembers = vi.fn();
+
+  const channelService = {
+    listServerChannels: vi.fn(),
+  } as unknown as ChannelService;
+  const serverService = {
+    listServers: vi.fn(),
+    createServer: vi.fn(),
+    getServerForUser: vi.fn(),
+    listMembers,
+    getAnalytics: vi.fn(),
+    listAuditLogs: vi.fn(),
+    moderateUser: vi.fn(),
+    listInvites: vi.fn(),
+    createInvite: vi.fn(),
+    revokeInvite: vi.fn(),
+    joinByInvite: vi.fn(),
+  } as unknown as ServerService;
+
+  const fastify = {
+    get: vi.fn((path: string, options: CapturedRoute['options'], handler: RouteHandler) => {
+      routes.push({ method: 'GET', path, options, handler });
+    }),
+    post: vi.fn((path: string, options: CapturedRoute['options'], handler: RouteHandler) => {
+      routes.push({ method: 'POST', path, options, handler });
+    }),
+    delete: vi.fn((path: string, options: CapturedRoute['options'], handler: RouteHandler) => {
+      routes.push({ method: 'DELETE', path, options, handler });
+    }),
+  };
+
+  await serverRoutes(fastify as never, {
+    channelService,
+    serverService,
+  });
+
+  const membersRoute = routes.find(
+    (route) => route.method === 'GET' && route.path === '/servers/:serverId/members',
+  );
+  if (!membersRoute) {
+    throw new Error('members route was not registered');
+  }
+
+  return {
+    membersRoute,
+    listMembers,
+  };
+}
+
+describe('serverRoutes /servers/:serverId/members', () => {
+  it('registers members route with auth pre-handler', async () => {
+    const { membersRoute } = await registerRoutes();
+
+    expect(Array.isArray(membersRoute.options.preHandler)).toBe(true);
+    expect(membersRoute.options.preHandler).toHaveLength(1);
+  });
+
+  it('returns server members for managing users', async () => {
+    const { membersRoute, listMembers } = await registerRoutes();
+    const members = [
+      {
+        id: 'a4c9b6a2-13f6-45a3-bc69-d9f267f8af53',
+        userId: '8dc6be31-7df5-4021-bce5-1f4dcb5cd771',
+        role: 'MEMBER',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+        user: {
+          id: '8dc6be31-7df5-4021-bce5-1f4dcb5cd771',
+          username: 'alice',
+          avatarUrl: null,
+        },
+      },
+    ];
+    listMembers.mockResolvedValue(members);
+
+    const response = await membersRoute.handler(
+      {
+        params: {
+          serverId: 'a78e3d9d-893a-4eec-b233-6191cfce53fb',
+        },
+        user: {
+          userId: '6e71d5ce-f616-4e2a-b655-7d80e1c1f8aa',
+        },
+      },
+      {},
+    );
+
+    expect(listMembers).toHaveBeenCalledWith(
+      '6e71d5ce-f616-4e2a-b655-7d80e1c1f8aa',
+      'a78e3d9d-893a-4eec-b233-6191cfce53fb',
+    );
+    expect(response).toEqual({ members });
+  });
+});
+

--- a/backend/tests/server.service.test.ts
+++ b/backend/tests/server.service.test.ts
@@ -50,6 +50,7 @@ function buildServerRepo(overrides: Partial<ServerRepository>): ServerRepository
     upsertDefault: overrides.upsertDefault ?? notImplemented,
     ensureAllUsersAreMembers: overrides.ensureAllUsersAreMembers ?? (async () => 0),
     findMember: overrides.findMember ?? (async () => null),
+    listMembers: overrides.listMembers ?? (async () => []),
     ensureMember: overrides.ensureMember ?? notImplemented,
     createInvite: overrides.createInvite ?? notImplemented,
     listInvites: overrides.listInvites ?? (async () => []),
@@ -134,6 +135,9 @@ describe('ServerService', () => {
 
   it('deduplicates slugs when creating servers', async () => {
     const created = buildServer({ id: 'server-2', slug: 'my-server-2', name: 'My Server' });
+    const ensurePublicByName = vi.fn().mockResolvedValue({});
+    const findByNameInServer = vi.fn().mockResolvedValue(null);
+    const createVoice = vi.fn().mockResolvedValue({});
     const service = new ServerService(
       buildServerRepo({
         findBySlug: vi
@@ -142,11 +146,27 @@ describe('ServerService', () => {
           .mockResolvedValueOnce(null),
         create: vi.fn().mockResolvedValue(created),
       }),
-      buildChannelRepo({}),
+      buildChannelRepo({
+        ensurePublicByName,
+        findByNameInServer,
+        createVoice,
+      }),
     );
 
     const server = await service.createServer('owner-1', { name: 'My Server' });
     expect(server.slug).toBe('my-server-2');
+    expect(ensurePublicByName).toHaveBeenCalledWith({
+      name: 'general',
+      serverId: 'server-2',
+    });
+    expect(findByNameInServer).toHaveBeenCalledWith({
+      serverId: 'server-2',
+      name: 'voice',
+    });
+    expect(createVoice).toHaveBeenCalledWith({
+      name: 'voice',
+      serverId: 'server-2',
+    });
   });
 
   it('rejects expired invites', async () => {

--- a/web/src/api/chat-api.ts
+++ b/web/src/api/chat-api.ts
@@ -17,6 +17,7 @@ import type {
   ServerAnalytics,
   ServerAuditLog,
   ServerInviteSummary,
+  ServerMemberSummary,
   ServerSummary,
   User,
   UserRole,
@@ -193,6 +194,10 @@ export const chatApi = {
 
   serverChannels(token: string, serverId: string) {
     return apiRequest<{ channels: Channel[] }>(`/servers/${serverId}/channels`, {}, token);
+  },
+
+  serverMembers(token: string, serverId: string) {
+    return apiRequest<{ members: ServerMemberSummary[] }>(`/servers/${serverId}/members`, {}, token);
   },
 
   serverAnalytics(token: string, serverId: string) {

--- a/web/src/components/channel-sidebar.tsx
+++ b/web/src/components/channel-sidebar.tsx
@@ -9,12 +9,17 @@ interface ChannelSidebarProps {
   activeChannelId: string | null;
   onSelect: (channelId: string) => void;
   unreadChannelCounts: Record<string, number>;
-  activeView: 'chat' | 'friends' | 'settings' | 'admin';
-  onChangeView: (view: 'chat' | 'friends' | 'settings' | 'admin') => void;
+  activeView: 'chat' | 'friends' | 'settings' | 'admin' | 'server';
+  onChangeView: (view: 'chat' | 'friends' | 'settings' | 'admin' | 'server') => void;
+  scope: 'home' | 'server';
+  scopeLabel: string;
   onLogout: () => Promise<void>;
   userId: string;
   username: string;
   isAdmin: boolean;
+  canManageScope: boolean;
+  canOpenServerView: boolean;
+  onOpenServerView: () => void;
   onCreateChannel: (name: string, type: 'TEXT' | 'VOICE') => Promise<void>;
   onDeleteChannel: (channelId: string) => Promise<void>;
   deletingChannelId: string | null;
@@ -143,9 +148,9 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
         <div className="channel-header-row">
           <div className="channel-brand">
             <img className="channel-brand-logo" src={harmonyLogo} alt="Harmony logo" />
-            <h2>Harmony</h2>
+            <h2>{props.scopeLabel}</h2>
           </div>
-          {props.isAdmin ? (
+          {props.canManageScope ? (
             <button
               className={showCreateChannel ? 'channel-add-btn active' : 'channel-add-btn'}
               aria-label="Create channel"
@@ -164,7 +169,7 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
       </header>
 
       <nav>
-        {props.isAdmin && showCreateChannel ? (
+        {props.canManageScope && showCreateChannel ? (
           <form
             className="channel-create-form"
             onSubmit={async (event) => {
@@ -265,7 +270,7 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
         {textChannels.length > 0 ? <p className="channel-group-label">Text Channels</p> : null}
         {textChannels.map((channel) => {
           const isDeleting = props.deletingChannelId === channel.id;
-          const canDelete = props.isAdmin && channel.name !== 'global';
+          const canDelete = props.canManageScope && channel.name !== 'global';
           return (
             <div key={channel.id} className="channel-row">
               <button
@@ -306,7 +311,7 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
         {voiceChannels.length > 0 ? <p className="channel-group-label">Voice Channels</p> : null}
         {voiceChannels.map((channel) => {
           const isDeleting = props.deletingChannelId === channel.id;
-          const canDelete = props.isAdmin;
+          const canDelete = props.canManageScope;
           const isJoined = props.activeVoiceChannelId === channel.id;
           const channelParticipants = props.voiceParticipantsByChannel[channel.id] ?? [];
           const streamingSet = new Set(props.voiceStreamingUserIdsByChannel[channel.id] ?? []);
@@ -463,7 +468,10 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
             </div>
           );
         })}
-        {filteredChannels.length === 0 ? <p className="muted">No channels match.</p> : null}
+        {props.scope === 'home' && filteredChannels.length === 0 && !query ? (
+          <p className="muted">No direct messages yet.</p>
+        ) : null}
+        {filteredChannels.length === 0 && query ? <p className="muted">No channels match.</p> : null}
       </nav>
 
       <footer>
@@ -517,6 +525,16 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
                 onClick={() => props.onChangeView('admin')}
               >
                 <svg width="20" height="20" viewBox="0 0 24 24"><path fill="currentColor" d="M12 1 3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4Zm0 4.18 5 2.22V11c0 3.87-2.47 7.63-5 8.87-2.53-1.24-5-5-5-8.87V7.4l5-2.22Z"></path></svg>
+              </button>
+            ) : null}
+            {props.canOpenServerView ? (
+              <button
+                className={props.activeView === 'server' ? 'control-btn active' : 'control-btn'}
+                aria-label="Server settings"
+                title="Server Management"
+                onClick={props.onOpenServerView}
+              >
+                <svg width="20" height="20" viewBox="0 0 24 24"><path fill="currentColor" d="M17 11V7a5 5 0 0 0-10 0v4H4v10h16V11h-3Zm-8 0V7a3 3 0 0 1 6 0v4H9Zm3 8a2 2 0 1 1 0-4 2 2 0 0 1 0 4Z"></path></svg>
               </button>
             ) : null}
             <button

--- a/web/src/components/server-management-panel.tsx
+++ b/web/src/components/server-management-panel.tsx
@@ -1,0 +1,325 @@
+import { useMemo, useState } from 'react';
+import type {
+  ModerationActionSummary,
+  ServerAnalytics,
+  ServerAuditLog,
+  ServerInviteSummary,
+  ServerMemberSummary,
+  ServerSummary,
+} from '../types/api';
+
+type ModerationType = 'WARN' | 'TIMEOUT' | 'KICK' | 'BAN' | 'UNBAN';
+
+interface ServerManagementPanelProps {
+  server: ServerSummary | null;
+  canManage: boolean;
+  loading: boolean;
+  error: string | null;
+  invites: ServerInviteSummary[];
+  analytics: ServerAnalytics | null;
+  logs: ServerAuditLog[];
+  members: ServerMemberSummary[];
+  moderationActions: ModerationActionSummary[];
+  inviteBusy: boolean;
+  moderationBusy: boolean;
+  onRefresh: () => Promise<void>;
+  onCreateInvite: (input: { maxUses?: number; expiresInHours?: number }) => Promise<void>;
+  onRevokeInvite: (inviteId: string) => Promise<void>;
+  onModerate: (input: {
+    targetUserId: string;
+    type: ModerationType;
+    reason?: string;
+    durationHours?: number;
+  }) => Promise<void>;
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) {
+    return '-';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '-';
+  }
+  return date.toLocaleString();
+}
+
+export function ServerManagementPanel({
+  server,
+  canManage,
+  loading,
+  error,
+  invites,
+  analytics,
+  logs,
+  members,
+  moderationActions,
+  inviteBusy,
+  moderationBusy,
+  onRefresh,
+  onCreateInvite,
+  onRevokeInvite,
+  onModerate,
+}: ServerManagementPanelProps) {
+  const [inviteMaxUses, setInviteMaxUses] = useState<number>(0);
+  const [inviteExpiresHours, setInviteExpiresHours] = useState<number>(24);
+  const [memberSearch, setMemberSearch] = useState('');
+  const [targetUserId, setTargetUserId] = useState('');
+  const [moderationType, setModerationType] = useState<ModerationType>('WARN');
+  const [moderationReason, setModerationReason] = useState('');
+  const [moderationDurationHours, setModerationDurationHours] = useState<number>(24);
+
+  const filteredMembers = useMemo(() => {
+    const query = memberSearch.trim().toLowerCase();
+    if (!query) {
+      return members;
+    }
+    return members.filter((member) => member.user.username.toLowerCase().includes(query));
+  }, [members, memberSearch]);
+
+  if (!server) {
+    return (
+      <section className="settings-panel">
+        <p className="muted">Select a server to manage.</p>
+      </section>
+    );
+  }
+
+  if (!canManage) {
+    return (
+      <section className="settings-panel">
+        <h2>{server.name}</h2>
+        <p className="muted">You need moderator-level server role to access server management.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="settings-panel server-management-panel">
+      <div className="admin-header">
+        <h2>Server Management</h2>
+        <button className="ghost-btn" disabled={loading} onClick={() => void onRefresh()}>
+          {loading ? 'Refreshing...' : 'Refresh'}
+        </button>
+      </div>
+
+      {error ? <p className="error-banner">{error}</p> : null}
+
+      <article className="setting-card">
+        <h3>{server.name}</h3>
+        <p className="muted">Slug: {server.slug}</p>
+        <p className="muted">Members: {server.memberCount}</p>
+        <p className="muted">Owner: @{server.owner.username}</p>
+      </article>
+
+      <article className="setting-card">
+        <h3>Invite Management</h3>
+        <form
+          className="server-management-invite-form"
+          onSubmit={async (event) => {
+            event.preventDefault();
+            await onCreateInvite({
+              maxUses: inviteMaxUses > 0 ? inviteMaxUses : undefined,
+              expiresInHours: inviteExpiresHours > 0 ? inviteExpiresHours : undefined,
+            });
+          }}
+        >
+          <label>
+            <span>Max Uses (0 = unlimited)</span>
+            <input
+              type="number"
+              min={0}
+              max={1000}
+              value={inviteMaxUses}
+              onChange={(event) => setInviteMaxUses(Math.max(0, Number(event.target.value) || 0))}
+            />
+          </label>
+          <label>
+            <span>Expires In Hours (0 = never)</span>
+            <input
+              type="number"
+              min={0}
+              max={24 * 30}
+              value={inviteExpiresHours}
+              onChange={(event) =>
+                setInviteExpiresHours(Math.max(0, Number(event.target.value) || 0))
+              }
+            />
+          </label>
+          <button className="ghost-btn" disabled={inviteBusy} type="submit">
+            {inviteBusy ? 'Creating...' : 'Create Invite'}
+          </button>
+        </form>
+        <div className="server-management-list">
+          {invites.map((invite) => (
+            <div key={invite.id} className="server-management-item">
+              <div>
+                <strong>{invite.code}</strong>
+                <small>
+                  Uses {invite.usesCount}
+                  {invite.maxUses ? ` / ${invite.maxUses}` : ''} | Expires {formatDate(invite.expiresAt)}
+                </small>
+              </div>
+              <button className="danger-btn" onClick={() => void onRevokeInvite(invite.id)}>
+                Revoke
+              </button>
+            </div>
+          ))}
+          {invites.length === 0 ? <p className="muted">No invites yet.</p> : null}
+        </div>
+      </article>
+
+      <article className="setting-card">
+        <h3>Analytics</h3>
+        {!analytics ? (
+          <p className="muted">No analytics available yet.</p>
+        ) : (
+          <div className="admin-user-stats">
+            <span className="status-chip neutral">Members {analytics.memberCount}</span>
+            <span className="status-chip neutral">Channels {analytics.channelCount}</span>
+            <span className="status-chip neutral">Msg 24h {analytics.messageCount24h}</span>
+            <span className="status-chip neutral">Msg 7d {analytics.messageCount7d}</span>
+            <span className="status-chip neutral">Active 24h {analytics.activeMembers24h}</span>
+            <span className="status-chip neutral">Mod 30d {analytics.moderationActions30d}</span>
+            <span className="status-chip neutral">Join 30d {analytics.inviteJoins30d}</span>
+          </div>
+        )}
+      </article>
+
+      <article className="setting-card">
+        <h3>Moderation</h3>
+        <form
+          className="server-management-moderation-form"
+          onSubmit={async (event) => {
+            event.preventDefault();
+            if (!targetUserId) {
+              return;
+            }
+            await onModerate({
+              targetUserId,
+              type: moderationType,
+              reason: moderationReason.trim() || undefined,
+              durationHours:
+                moderationType === 'TIMEOUT'
+                  ? Math.max(1, Number(moderationDurationHours) || 1)
+                  : undefined,
+            });
+          }}
+        >
+          <label>
+            <span>Action</span>
+            <select
+              value={moderationType}
+              onChange={(event) => setModerationType(event.target.value as ModerationType)}
+            >
+              <option value="WARN">WARN</option>
+              <option value="TIMEOUT">TIMEOUT</option>
+              <option value="KICK">KICK</option>
+              <option value="BAN">BAN</option>
+              <option value="UNBAN">UNBAN</option>
+            </select>
+          </label>
+          <label>
+            <span>Target User ID</span>
+            <input
+              value={targetUserId}
+              onChange={(event) => setTargetUserId(event.target.value)}
+              placeholder="Select a member below or paste user id"
+            />
+          </label>
+          <label>
+            <span>Reason</span>
+            <input
+              value={moderationReason}
+              onChange={(event) => setModerationReason(event.target.value)}
+              placeholder="Optional reason"
+            />
+          </label>
+          {moderationType === 'TIMEOUT' ? (
+            <label>
+              <span>Duration (hours)</span>
+              <input
+                type="number"
+                min={1}
+                max={24 * 30}
+                value={moderationDurationHours}
+                onChange={(event) =>
+                  setModerationDurationHours(
+                    Math.max(1, Math.min(24 * 30, Number(event.target.value) || 1)),
+                  )
+                }
+              />
+            </label>
+          ) : null}
+          <button className="ghost-btn" disabled={moderationBusy} type="submit">
+            {moderationBusy ? 'Submitting...' : 'Submit Action'}
+          </button>
+        </form>
+
+        <label className="field-inline">
+          <span>
+            <strong>Members</strong>
+            <small>Filter and pick target user.</small>
+          </span>
+          <input
+            className="admin-user-search"
+            value={memberSearch}
+            onChange={(event) => setMemberSearch(event.target.value)}
+            placeholder="Search members"
+          />
+        </label>
+
+        <div className="server-management-list">
+          {filteredMembers.map((member) => (
+            <div key={member.id} className="server-management-item">
+              <div>
+                <strong>@{member.user.username}</strong>
+                <small>
+                  {member.role} | Joined {formatDate(member.createdAt)}
+                </small>
+              </div>
+              <button className="ghost-btn small" onClick={() => setTargetUserId(member.userId)}>
+                Target
+              </button>
+            </div>
+          ))}
+          {filteredMembers.length === 0 ? <p className="muted">No members found.</p> : null}
+        </div>
+
+        <h4>Recent moderation actions</h4>
+        <div className="server-management-list">
+          {moderationActions.map((action) => (
+            <div key={action.id} className="server-management-item">
+              <div>
+                <strong>{action.type}</strong>
+                <small>
+                  @{action.targetUser.username} by @{action.actor.username} at {formatDate(action.createdAt)}
+                </small>
+              </div>
+            </div>
+          ))}
+          {moderationActions.length === 0 ? <p className="muted">No moderation actions yet.</p> : null}
+        </div>
+      </article>
+
+      <article className="setting-card">
+        <h3>Audit Logs</h3>
+        <div className="server-management-list">
+          {logs.map((log) => (
+            <div key={log.id} className="server-management-item">
+              <div>
+                <strong>{log.action}</strong>
+                <small>
+                  {formatDate(log.createdAt)} | Actor {log.actor ? `@${log.actor.username}` : '-'} | Target{' '}
+                  {log.targetUser ? `@${log.targetUser.username}` : '-'}
+                </small>
+              </div>
+            </div>
+          ))}
+          {logs.length === 0 ? <p className="muted">No audit entries.</p> : null}
+        </div>
+      </article>
+    </section>
+  );
+}
+

--- a/web/src/components/server-rail.tsx
+++ b/web/src/components/server-rail.tsx
@@ -1,0 +1,94 @@
+import type { ServerSummary } from '../types/api';
+import type { RailScope } from '../pages/chat/utils/server-scope';
+import { resolveMediaUrl } from '../utils/media-url';
+
+interface ServerRailProps {
+  servers: ServerSummary[];
+  scope: RailScope;
+  onSelectHome: () => void;
+  onSelectServer: (serverId: string) => void;
+  onCreateServer: () => void;
+  onJoinServer: () => void;
+  creatingServer: boolean;
+  joiningServer: boolean;
+}
+
+function initialsFromName(name: string) {
+  return name
+    .trim()
+    .split(/\s+/)
+    .map((part) => part.slice(0, 1))
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+export function ServerRail({
+  servers,
+  scope,
+  onSelectHome,
+  onSelectServer,
+  onCreateServer,
+  onJoinServer,
+  creatingServer,
+  joiningServer,
+}: ServerRailProps) {
+  return (
+    <aside className="server-rail" aria-label="Servers">
+      <button
+        className={scope.kind === 'home' ? 'server-rail-item active home' : 'server-rail-item home'}
+        onClick={onSelectHome}
+        title="Home"
+        aria-label="Home"
+      >
+        H
+      </button>
+      <div className="server-rail-divider" />
+      <div className="server-rail-list">
+        {servers.map((server) => {
+          const iconUrl = resolveMediaUrl(server.iconUrl);
+          return (
+            <button
+              key={server.id}
+              className={
+                scope.kind === 'server' && scope.serverId === server.id
+                  ? 'server-rail-item active'
+                  : 'server-rail-item'
+              }
+              onClick={() => onSelectServer(server.id)}
+              title={server.name}
+              aria-label={server.name}
+            >
+              {iconUrl ? (
+                <img src={iconUrl} alt={server.name} />
+              ) : (
+                <span>{initialsFromName(server.name) || 'S'}</span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+      <div className="server-rail-actions">
+        <button
+          className="server-rail-item action"
+          onClick={onCreateServer}
+          disabled={creatingServer}
+          title="Create server"
+          aria-label="Create server"
+        >
+          +
+        </button>
+        <button
+          className="server-rail-item action"
+          onClick={onJoinServer}
+          disabled={joiningServer}
+          title="Join server by invite"
+          aria-label="Join server by invite"
+        >
+          #
+        </button>
+      </div>
+    </aside>
+  );
+}
+

--- a/web/src/pages/chat-page.tsx
+++ b/web/src/pages/chat-page.tsx
@@ -34,12 +34,26 @@ import { useVoiceFeature } from './chat/hooks/use-voice-feature';
 import { useAuth } from '../store/auth-store';
 import type {
   Channel,
+  ModerationActionSummary,
   Message,
+  ServerAnalytics,
+  ServerAuditLog,
+  ServerInviteSummary,
+  ServerMemberSummary,
+  ServerSummary,
 } from '../types/api';
 import { getErrorMessage } from '../utils/error-message';
 import { trackTelemetry } from '../utils/telemetry';
+import {
+  filterChannelsForScope,
+  findServerByScope,
+  isChannelVisibleInScope,
+  isServerManagerRole,
+  pickFallbackChannelId,
+  type RailScope,
+} from './chat/utils/server-scope';
 
-type MainView = 'chat' | 'friends' | 'settings' | 'admin';
+type MainView = 'chat' | 'friends' | 'settings' | 'admin' | 'server';
 type MobilePane = 'none' | 'channels' | 'users';
 type StreamSource = 'screen' | 'camera';
 type VoiceReconnectIntent = {
@@ -122,6 +136,8 @@ export function ChatPage() {
   const { preferences, updatePreferences, resetPreferences, applyVoiceDefaults } = useUserPreferences();
 
   const [channels, setChannels] = useState<Channel[]>([]);
+  const [servers, setServers] = useState<ServerSummary[]>([]);
+  const [railScope, setRailScope] = useState<RailScope>({ kind: 'home' });
   const [activeChannelId, setActiveChannelId] = useState<string | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
   const [messageQuery, setMessageQuery] = useState('');
@@ -144,6 +160,17 @@ export function ChatPage() {
   const [voiceSfuEnabled, setVoiceSfuEnabled] = useState(false);
   const [voiceSfuProvider, setVoiceSfuProvider] = useState<'mediasoup' | 'cloudflare'>('mediasoup');
   const voiceSfuClientRef = useRef<VoiceSfuClientLike | null>(null);
+  const [creatingServer, setCreatingServer] = useState(false);
+  const [joiningServer, setJoiningServer] = useState(false);
+  const [serverPanelLoading, setServerPanelLoading] = useState(false);
+  const [serverPanelError, setServerPanelError] = useState<string | null>(null);
+  const [serverInvites, setServerInvites] = useState<ServerInviteSummary[]>([]);
+  const [serverAnalytics, setServerAnalytics] = useState<ServerAnalytics | null>(null);
+  const [serverAuditLogs, setServerAuditLogs] = useState<ServerAuditLog[]>([]);
+  const [serverMembers, setServerMembers] = useState<ServerMemberSummary[]>([]);
+  const [serverModerationActions, setServerModerationActions] = useState<ModerationActionSummary[]>([]);
+  const [serverInviteBusy, setServerInviteBusy] = useState(false);
+  const [serverModerationBusy, setServerModerationBusy] = useState(false);
 
   const [composerInsertRequest, setComposerInsertRequest] = useState<{
     key: number;
@@ -253,6 +280,13 @@ export function ChatPage() {
     console.debug('[voice-debug]', payload);
   }, []);
 
+  const selectedServer = useMemo(() => findServerByScope(servers, railScope), [servers, railScope]);
+  const selectedServerId = selectedServer?.id ?? null;
+  const scopedChannels = useMemo(() => filterChannelsForScope(channels, railScope), [channels, railScope]);
+  const canManageSelectedServer = useMemo(
+    () => isServerManagerRole(selectedServer?.memberRole),
+    [selectedServer?.memberRole],
+  );
   const activeChannel = useMemo(
     () => channels.find((channel) => channel.id === activeChannelId) ?? null,
     [channels, activeChannelId],
@@ -838,7 +872,6 @@ export function ChatPage() {
     activeVoiceChannel,
     activeVoiceBitrateKbps,
     activeStreamBitrateKbps,
-    canEditVoiceSettings,
     voiceParticipantCounts,
     activeVoiceParticipants,
     voiceStreamingUserIdsByChannel,
@@ -887,8 +920,8 @@ export function ChatPage() {
     deleteChannel,
   } = useChannelManagementFeature({
     authToken: auth.token,
-    isAdmin: auth.user?.isAdmin,
-    canEditVoiceSettings,
+    canManageChannels: canManageSelectedServer,
+    canEditVoiceSettings: canManageSelectedServer,
     activeChannelId,
     activeVoiceChannelId,
     leaveVoice: (channelId) => hookLeaveVoiceRef.current(channelId),
@@ -900,6 +933,184 @@ export function ChatPage() {
     setActiveVoiceChannelId,
     setError,
   });
+
+  const mergeChannels = useCallback((incoming: Channel[]) => {
+    setChannels((prev) => {
+      const byId = new Map(prev.map((channel) => [channel.id, channel]));
+      for (const channel of incoming) {
+        byId.set(channel.id, channel);
+      }
+      return [...byId.values()].sort(
+        (left, right) =>
+          new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime(),
+      );
+    });
+  }, []);
+
+  const selectHomeScope = useCallback(() => {
+    setRailScope({ kind: 'home' });
+    setActiveView('chat');
+    setMobilePane('none');
+  }, []);
+
+  const selectServerScope = useCallback((serverId: string) => {
+    setRailScope({ kind: 'server', serverId });
+    setActiveView('chat');
+    setMobilePane('none');
+  }, []);
+
+  const createScopedChannel = useCallback(
+    async (name: string, type: 'TEXT' | 'VOICE') => {
+      if (!selectedServerId) {
+        setError('Select a server first');
+        return;
+      }
+      await createChannel(name, type, selectedServerId);
+    },
+    [createChannel, selectedServerId, setError],
+  );
+
+  const createServerFromRail = useCallback(async () => {
+    if (!auth.token) {
+      return;
+    }
+    const name = window.prompt('Server name');
+    if (!name || !name.trim()) {
+      return;
+    }
+    setCreatingServer(true);
+    try {
+      const response = await chatApi.createServer(auth.token, { name: name.trim() });
+      setServers((prev) => {
+        const exists = prev.some((server) => server.id === response.server.id);
+        return exists ? prev : [...prev, response.server];
+      });
+      const channelsResponse = await chatApi.serverChannels(auth.token, response.server.id);
+      mergeChannels(channelsResponse.channels);
+      setRailScope({ kind: 'server', serverId: response.server.id });
+      setActiveView('chat');
+      setActiveChannelId(channelsResponse.channels[0]?.id ?? null);
+      setNotice(`Server ${response.server.name} created.`);
+      setError(null);
+    } catch (err) {
+      setError(getErrorMessage(err, 'Could not create server'));
+    } finally {
+      setCreatingServer(false);
+    }
+  }, [auth.token, mergeChannels, setError]);
+
+  const joinServerFromRail = useCallback(async () => {
+    if (!auth.token) {
+      return;
+    }
+    const code = window.prompt('Invite code');
+    if (!code || !code.trim()) {
+      return;
+    }
+    setJoiningServer(true);
+    try {
+      const response = await chatApi.joinServerByInvite(auth.token, code.trim());
+      setServers((prev) => {
+        const exists = prev.some((server) => server.id === response.server.id);
+        return exists ? prev : [...prev, response.server];
+      });
+      const channelsResponse = await chatApi.serverChannels(auth.token, response.server.id);
+      mergeChannels(channelsResponse.channels);
+      setRailScope({ kind: 'server', serverId: response.server.id });
+      setActiveView('chat');
+      setActiveChannelId(channelsResponse.channels[0]?.id ?? null);
+      setNotice(`Joined ${response.server.name}.`);
+      setError(null);
+    } catch (err) {
+      setError(getErrorMessage(err, 'Could not join server'));
+    } finally {
+      setJoiningServer(false);
+    }
+  }, [auth.token, mergeChannels, setError]);
+
+  const loadServerManagementData = useCallback(async () => {
+    if (!auth.token || !selectedServerId || !canManageSelectedServer) {
+      return;
+    }
+    setServerPanelLoading(true);
+    try {
+      const [invitesResponse, analyticsResponse, logsResponse, membersResponse] = await Promise.all([
+        chatApi.serverInvites(auth.token, selectedServerId),
+        chatApi.serverAnalytics(auth.token, selectedServerId),
+        chatApi.serverAuditLogs(auth.token, selectedServerId, 50),
+        chatApi.serverMembers(auth.token, selectedServerId),
+      ]);
+      setServerInvites(invitesResponse.invites);
+      setServerAnalytics(analyticsResponse.analytics);
+      setServerAuditLogs(logsResponse.logs);
+      setServerMembers(membersResponse.members);
+      setServerPanelError(null);
+    } catch (err) {
+      setServerPanelError(getErrorMessage(err, 'Could not load server management data'));
+    } finally {
+      setServerPanelLoading(false);
+    }
+  }, [auth.token, selectedServerId, canManageSelectedServer]);
+
+  const createServerInvite = useCallback(
+    async (input: { maxUses?: number; expiresInHours?: number }) => {
+      if (!auth.token || !selectedServerId) {
+        return;
+      }
+      setServerInviteBusy(true);
+      try {
+        await chatApi.createServerInvite(auth.token, selectedServerId, input);
+        await loadServerManagementData();
+      } catch (err) {
+        setServerPanelError(getErrorMessage(err, 'Could not create invite'));
+      } finally {
+        setServerInviteBusy(false);
+      }
+    },
+    [auth.token, selectedServerId, loadServerManagementData],
+  );
+
+  const revokeServerInvite = useCallback(
+    async (inviteId: string) => {
+      if (!auth.token || !selectedServerId) {
+        return;
+      }
+      setServerInviteBusy(true);
+      try {
+        await chatApi.revokeServerInvite(auth.token, selectedServerId, inviteId);
+        await loadServerManagementData();
+      } catch (err) {
+        setServerPanelError(getErrorMessage(err, 'Could not revoke invite'));
+      } finally {
+        setServerInviteBusy(false);
+      }
+    },
+    [auth.token, selectedServerId, loadServerManagementData],
+  );
+
+  const moderateServerMember = useCallback(
+    async (input: {
+      targetUserId: string;
+      type: 'WARN' | 'TIMEOUT' | 'KICK' | 'BAN' | 'UNBAN';
+      reason?: string;
+      durationHours?: number;
+    }) => {
+      if (!auth.token || !selectedServerId) {
+        return;
+      }
+      setServerModerationBusy(true);
+      try {
+        const response = await chatApi.moderateServerUser(auth.token, selectedServerId, input);
+        setServerModerationActions((prev) => [response.action, ...prev].slice(0, 25));
+        await loadServerManagementData();
+      } catch (err) {
+        setServerPanelError(getErrorMessage(err, 'Could not submit moderation action'));
+      } finally {
+        setServerModerationBusy(false);
+      }
+    },
+    [auth.token, selectedServerId, loadServerManagementData],
+  );
 
   useRemoteSpeakingActivity({
     enabled: preferences.showVoiceActivity,
@@ -1129,6 +1340,14 @@ export function ChatPage() {
     if (auth.token) {
       return;
     }
+    setServers([]);
+    setRailScope({ kind: 'home' });
+    setServerInvites([]);
+    setServerAnalytics(null);
+    setServerAuditLogs([]);
+    setServerMembers([]);
+    setServerModerationActions([]);
+    setServerPanelError(null);
     reconnectVoiceIntentRef.current = null;
     setOnlineUsers([]);
     setUnreadChannelCounts({});
@@ -1148,16 +1367,30 @@ export function ChatPage() {
     const token = auth.token;
     const load = async () => {
       try {
-        const response = await chatApi.channels(token);
+        const [channelsResponse, serversResponse] = await Promise.all([
+          chatApi.channels(token),
+          chatApi.servers(token),
+        ]);
         if (disposed) {
           return;
         }
-        setChannels(response.channels);
+        setChannels(channelsResponse.channels);
+        setServers(serversResponse.servers);
+        const nextScope: RailScope = { kind: 'home' };
+        setRailScope(nextScope);
+        setActiveView('chat');
+        setServerInvites([]);
+        setServerAnalytics(null);
+        setServerAuditLogs([]);
+        setServerMembers([]);
+        setServerModerationActions([]);
+        setServerPanelError(null);
         setError(null);
-        setActiveChannelId((current) => current ?? response.channels[0]?.id ?? null);
+        const firstHomeChannelId = pickFallbackChannelId(channelsResponse.channels, nextScope);
+        setActiveChannelId(firstHomeChannelId);
       } catch (err) {
         if (!disposed) {
-          setError(getErrorMessage(err, 'Could not load channels'));
+          setError(getErrorMessage(err, 'Could not load chat data'));
         }
       }
     };
@@ -1195,6 +1428,64 @@ export function ChatPage() {
         : `You received ${newRequestCount} friend requests.`,
     );
   }, [auth.token, incomingRequests.length]);
+
+  useEffect(() => {
+    if (railScope.kind !== 'server') {
+      return;
+    }
+    if (selectedServer) {
+      return;
+    }
+    setRailScope({ kind: 'home' });
+    setActiveView('chat');
+  }, [railScope, selectedServer]);
+
+  useEffect(() => {
+    if (activeView === 'server' && railScope.kind === 'home') {
+      setActiveView('chat');
+    }
+  }, [activeView, railScope.kind]);
+
+  useEffect(() => {
+    if (activeView !== 'chat') {
+      return;
+    }
+    if (!activeChannelId) {
+      const fallback = pickFallbackChannelId(channels, railScope);
+      if (fallback) {
+        setActiveChannelId(fallback);
+      }
+      return;
+    }
+    const current = channels.find((channel) => channel.id === activeChannelId) ?? null;
+    if (!current) {
+      return;
+    }
+    if (isChannelVisibleInScope(current, railScope)) {
+      return;
+    }
+    setActiveChannelId(pickFallbackChannelId(channels, railScope));
+  }, [activeView, activeChannelId, channels, railScope]);
+
+  useEffect(() => {
+    if (activeView !== 'server' || !selectedServerId || !canManageSelectedServer) {
+      return;
+    }
+    void loadServerManagementData();
+  }, [activeView, selectedServerId, canManageSelectedServer, loadServerManagementData]);
+
+  useEffect(() => {
+    if (railScope.kind === 'server') {
+      setServerPanelError(null);
+      return;
+    }
+    setServerInvites([]);
+    setServerAnalytics(null);
+    setServerAuditLogs([]);
+    setServerMembers([]);
+    setServerModerationActions([]);
+    setServerPanelError(null);
+  }, [railScope.kind, selectedServerId]);
 
   const { toggleMessageReaction } = useReactionsFeature({
     authToken: auth.token,
@@ -1255,6 +1546,7 @@ export function ChatPage() {
     auth.clearAuth();
   };
 
+  const scopeLabel = railScope.kind === 'home' ? 'Home' : (selectedServer?.name ?? 'Server');
   const panelTitle =
     activeView === 'chat'
       ? activeChannel
@@ -1263,12 +1555,16 @@ export function ChatPage() {
           : activeChannel.isVoice
             ? `~${activeChannel.name}`
             : `#${activeChannel.name}`
-        : 'Select channel'
+        : railScope.kind === 'home'
+          ? 'Home'
+          : `${scopeLabel} / Select channel`
       : activeView === 'friends'
         ? 'Friends'
         : activeView === 'settings'
           ? 'Settings'
-          : 'Admin Settings';
+          : activeView === 'server'
+            ? `${scopeLabel} Management`
+            : 'Admin Settings';
   const isVoiceDisconnecting =
     Boolean(activeVoiceChannelId) && voiceBusyChannelId === activeVoiceChannelId;
   const isViewingJoinedVoiceChannel =
@@ -1353,8 +1649,22 @@ export function ChatPage() {
   return (
     <ChatPageShell
       chatLayoutClassName={chatLayoutClassName}
+      serverRailProps={{
+        servers,
+        scope: railScope,
+        onSelectHome: selectHomeScope,
+        onSelectServer: selectServerScope,
+        onCreateServer: () => {
+          void createServerFromRail();
+        },
+        onJoinServer: () => {
+          void joinServerFromRail();
+        },
+        creatingServer,
+        joiningServer,
+      }}
       sidebarProps={{
-        channels,
+        channels: scopedChannels,
         activeChannelId,
         onSelect: (channelId) => {
           setActiveChannelId(channelId);
@@ -1372,11 +1682,16 @@ export function ChatPage() {
         unreadChannelCounts,
         activeView,
         onChangeView: setActiveView,
+        scope: railScope.kind,
+        scopeLabel,
         onLogout: logout,
         userId: auth.user.id,
         username: auth.user.username,
         isAdmin: auth.user.isAdmin,
-        onCreateChannel: createChannel,
+        canManageScope: railScope.kind === 'server' && canManageSelectedServer,
+        canOpenServerView: railScope.kind === 'server' && canManageSelectedServer,
+        onOpenServerView: () => setActiveView('server'),
+        onCreateChannel: createScopedChannel,
         onDeleteChannel: deleteChannel,
         deletingChannelId,
         activeVoiceChannelId,
@@ -1448,7 +1763,10 @@ export function ChatPage() {
             onStreamBitrateChange: (nextBitrate) => {
               void updateVoiceChannelSettings(activeChannel.id, { streamBitrateKbps: nextBitrate });
             },
-            canEditChannelBitrate: canEditVoiceSettings,
+            canEditChannelBitrate:
+              railScope.kind === 'server' &&
+              activeChannel.serverId === railScope.serverId &&
+              canManageSelectedServer,
             qualityBusy: savingVoiceSettingsChannelId === activeChannel.id,
             joined: activeVoiceChannelId === activeChannel.id,
             busy: voiceBusyChannelId === activeChannel.id,
@@ -1589,6 +1907,27 @@ export function ChatPage() {
           }
           : null
       }
+      serverPanelProps={
+        activeView === 'server'
+          ? {
+            server: selectedServer,
+            canManage: canManageSelectedServer,
+            loading: serverPanelLoading,
+            error: serverPanelError,
+            invites: serverInvites,
+            analytics: serverAnalytics,
+            logs: serverAuditLogs,
+            members: serverMembers,
+            moderationActions: serverModerationActions,
+            inviteBusy: serverInviteBusy,
+            moderationBusy: serverModerationBusy,
+            onRefresh: loadServerManagementData,
+            onCreateInvite: createServerInvite,
+            onRevokeInvite: revokeServerInvite,
+            onModerate: moderateServerMember,
+          }
+          : null
+      }
       userSidebarProps={{
         users: onlineUsers,
         onUserClick: (user) => {
@@ -1726,6 +2065,19 @@ export function ChatPage() {
           }}
         >
           Friends
+        </button>
+        <button
+          className={activeView === 'server' ? 'active' : ''}
+          disabled={railScope.kind !== 'server'}
+          onClick={() => {
+            if (railScope.kind !== 'server') {
+              return;
+            }
+            setActiveView('server');
+            setMobilePane('none');
+          }}
+        >
+          Server
         </button>
         <button
           className={activeView === 'settings' ? 'active' : ''}

--- a/web/src/pages/chat/components/chat-page-shell.tsx
+++ b/web/src/pages/chat/components/chat-page-shell.tsx
@@ -4,11 +4,13 @@ import { ChannelSidebar } from '../../../components/channel-sidebar';
 import { ChatView } from '../../../components/chat-view';
 import { FriendsPanel } from '../../../components/friends-panel';
 import { MessageComposer } from '../../../components/message-composer';
+import { ServerManagementPanel } from '../../../components/server-management-panel';
+import { ServerRail } from '../../../components/server-rail';
 import { SettingsPanel } from '../../../components/settings-panel';
 import { UserSidebar } from '../../../components/user-sidebar';
 import { VoiceChannelPanel } from '../../../components/voice-channel-panel';
 
-type MainView = 'chat' | 'friends' | 'settings' | 'admin';
+type MainView = 'chat' | 'friends' | 'settings' | 'admin' | 'server';
 type MobilePane = 'none' | 'channels' | 'users';
 
 type StreamStatusBanner = {
@@ -29,6 +31,7 @@ type ActiveVoiceSession = {
 
 type ChatPageShellProps = {
   chatLayoutClassName: string;
+  serverRailProps: ComponentProps<typeof ServerRail>;
   sidebarProps: ComponentProps<typeof ChannelSidebar>;
   activeView: MainView;
   activeChannelIsVoice: boolean;
@@ -48,12 +51,14 @@ type ChatPageShellProps = {
   friendsPanelProps: ComponentProps<typeof FriendsPanel>;
   settingsPanelProps: ComponentProps<typeof SettingsPanel>;
   adminPanelProps: ComponentProps<typeof AdminSettingsPanel> | null;
+  serverPanelProps: ComponentProps<typeof ServerManagementPanel> | null;
   userSidebarProps: ComponentProps<typeof UserSidebar>;
   children?: ReactNode;
 };
 
 export function ChatPageShell({
   chatLayoutClassName,
+  serverRailProps,
   sidebarProps,
   activeView,
   activeChannelIsVoice,
@@ -73,11 +78,13 @@ export function ChatPageShell({
   friendsPanelProps,
   settingsPanelProps,
   adminPanelProps,
+  serverPanelProps,
   userSidebarProps,
   children,
 }: ChatPageShellProps) {
   return (
     <main className={chatLayoutClassName}>
+      <ServerRail {...serverRailProps} />
       <ChannelSidebar {...sidebarProps} />
 
       <section className="chat-panel">
@@ -170,6 +177,10 @@ export function ChatPageShell({
 
         {activeView === 'admin' && adminPanelProps ? (
           <AdminSettingsPanel {...adminPanelProps} />
+        ) : null}
+
+        {activeView === 'server' && serverPanelProps ? (
+          <ServerManagementPanel {...serverPanelProps} />
         ) : null}
       </section>
 

--- a/web/src/pages/chat/hooks/use-channel-management-feature.ts
+++ b/web/src/pages/chat/hooks/use-channel-management-feature.ts
@@ -6,11 +6,11 @@ import type { Channel } from '../../../types/api';
 import { getErrorMessage } from '../../../utils/error-message';
 import { upsertChannel } from './use-profile-dm-feature';
 
-type MainView = 'chat' | 'friends' | 'settings' | 'admin';
+type MainView = 'chat' | 'friends' | 'settings' | 'admin' | 'server';
 
 type UseChannelManagementFeatureOptions = {
   authToken: string | null;
-  isAdmin: boolean | undefined;
+  canManageChannels: boolean;
   canEditVoiceSettings: boolean;
   activeChannelId: string | null;
   activeVoiceChannelId: string | null;
@@ -26,7 +26,7 @@ type UseChannelManagementFeatureOptions = {
 
 export function useChannelManagementFeature({
   authToken,
-  isAdmin,
+  canManageChannels,
   canEditVoiceSettings,
   activeChannelId,
   activeVoiceChannelId,
@@ -43,12 +43,12 @@ export function useChannelManagementFeature({
   const [savingVoiceSettingsChannelId, setSavingVoiceSettingsChannelId] = useState<string | null>(null);
 
   const createChannel = useCallback(
-    async (name: string, type: 'TEXT' | 'VOICE') => {
-      if (!authToken || !isAdmin) {
+    async (name: string, type: 'TEXT' | 'VOICE', serverId?: string) => {
+      if (!authToken || !canManageChannels) {
         return;
       }
       try {
-        const response = await chatApi.createChannel(authToken, name, type);
+        const response = await chatApi.createChannel(authToken, name, type, serverId);
         setChannels((prev) => {
           const exists = prev.some((channel) => channel.id === response.channel.id);
           return exists ? prev : [...prev, response.channel];
@@ -60,7 +60,7 @@ export function useChannelManagementFeature({
         setError(getErrorMessage(err, 'Could not create channel'));
       }
     },
-    [authToken, isAdmin, setChannels, setActiveChannelId, setActiveView, setError],
+    [authToken, canManageChannels, setChannels, setActiveChannelId, setActiveView, setError],
   );
 
   const updateVoiceChannelSettings = useCallback(
@@ -104,7 +104,7 @@ export function useChannelManagementFeature({
 
   const deleteChannel = useCallback(
     async (channelId: string) => {
-      if (!authToken || !isAdmin) {
+      if (!authToken || !canManageChannels) {
         return;
       }
       setDeletingChannelId(channelId);
@@ -144,7 +144,7 @@ export function useChannelManagementFeature({
     },
     [
       authToken,
-      isAdmin,
+      canManageChannels,
       activeVoiceChannelId,
       leaveVoice,
       setActiveVoiceChannelId,

--- a/web/src/pages/chat/hooks/use-chat-page-effects.ts
+++ b/web/src/pages/chat/hooks/use-chat-page-effects.ts
@@ -3,7 +3,7 @@ import type { Dispatch, RefObject, SetStateAction } from 'react';
 import type { Message } from '../../../types/api';
 import type { ReplyTarget } from './use-message-lifecycle-feature';
 
-type MainView = 'chat' | 'friends' | 'settings' | 'admin';
+type MainView = 'chat' | 'friends' | 'settings' | 'admin' | 'server';
 type MobilePane = 'none' | 'channels' | 'users';
 
 type UseChatPageEffectsOptions = {

--- a/web/src/pages/chat/utils/server-scope.ts
+++ b/web/src/pages/chat/utils/server-scope.ts
@@ -1,0 +1,42 @@
+import type { Channel, ServerSummary, UserRole } from '../../../types/api';
+
+export type RailScope =
+  | { kind: 'home' }
+  | {
+      kind: 'server';
+      serverId: string;
+    };
+
+export function isServerManagerRole(role: UserRole | null | undefined) {
+  return role === 'OWNER' || role === 'ADMIN' || role === 'MODERATOR';
+}
+
+export function findServerByScope(servers: ServerSummary[], scope: RailScope): ServerSummary | null {
+  if (scope.kind !== 'server') {
+    return null;
+  }
+  return servers.find((server) => server.id === scope.serverId) ?? null;
+}
+
+export function filterChannelsForScope(channels: Channel[], scope: RailScope): Channel[] {
+  if (scope.kind === 'home') {
+    return channels.filter((channel) => channel.isDirect);
+  }
+  return channels.filter((channel) => !channel.isDirect && channel.serverId === scope.serverId);
+}
+
+export function isChannelVisibleInScope(channel: Channel | null | undefined, scope: RailScope) {
+  if (!channel) {
+    return false;
+  }
+  if (scope.kind === 'home') {
+    return channel.isDirect;
+  }
+  return !channel.isDirect && channel.serverId === scope.serverId;
+}
+
+export function pickFallbackChannelId(channels: Channel[], scope: RailScope): string | null {
+  const inScope = filterChannelsForScope(channels, scope);
+  return inScope[0]?.id ?? null;
+}
+

--- a/web/src/styles/chat.css
+++ b/web/src/styles/chat.css
@@ -22,6 +22,76 @@ input,
   display: none;
 }
 
+/* Server Rail */
+
+.server-rail {
+  background-color: #121318;
+  border-right: 1px solid var(--panel-border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 0;
+  min-width: 0;
+}
+
+.server-rail-divider {
+  width: 36px;
+  height: 1px;
+  background: var(--panel-border);
+}
+
+.server-rail-list,
+.server-rail-actions {
+  display: grid;
+  gap: 8px;
+}
+
+.server-rail-list {
+  overflow-y: auto;
+  padding: 0 4px;
+}
+
+.server-rail-item {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-header);
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  transition: border-radius 0.14s ease, background-color 0.14s ease, border-color 0.14s ease;
+}
+
+.server-rail-item:hover {
+  border-radius: 18px;
+  background: rgba(88, 101, 242, 0.24);
+}
+
+.server-rail-item.active {
+  border-radius: 18px;
+  border-color: rgba(88, 101, 242, 0.6);
+  background: rgba(88, 101, 242, 0.38);
+}
+
+.server-rail-item.home {
+  font-size: 18px;
+}
+
+.server-rail-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.server-rail-item.action {
+  font-size: 19px;
+}
+
 /* Channel Sidebar */
 
 .channel-sidebar {
@@ -1630,7 +1700,7 @@ body.theme-light .select-option:hover {
 
 .chat-layout {
   display: grid;
-  grid-template-columns: 260px 1fr 260px;
+  grid-template-columns: 72px 260px 1fr 260px;
   grid-template-rows: minmax(0, 1fr);
   height: 100vh;
   height: 100dvh;
@@ -1710,6 +1780,44 @@ body.theme-light .select-option:hover {
 
 .chat-view-empty-state {
   margin-top: 54px;
+}
+
+.server-management-panel .setting-card h3 {
+  margin-top: 0;
+}
+
+.server-management-invite-form,
+.server-management-moderation-form {
+  display: grid;
+  gap: 10px;
+}
+
+.server-management-invite-form label,
+.server-management-moderation-form label {
+  display: grid;
+  gap: 6px;
+}
+
+.server-management-list {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.server-management-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px;
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.server-management-item small {
+  display: block;
+  color: var(--text-muted);
 }
 
 @media (max-width: 960px) {

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -1463,7 +1463,7 @@ body.font-scale-lg {
 
 @media (max-width: 900px) {
   .chat-layout {
-    grid-template-columns: 260px 1fr;
+    grid-template-columns: 72px 260px 1fr;
   }
 
   .user-sidebar {
@@ -1495,6 +1495,10 @@ body.font-scale-lg {
   .chat-layout {
     grid-template-columns: 1fr;
     position: relative;
+  }
+
+  .server-rail {
+    display: none;
   }
 
   .chat-panel {
@@ -1587,7 +1591,7 @@ body.font-scale-lg {
     bottom: 0;
     z-index: 38;
     display: grid;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
+    grid-template-columns: repeat(6, minmax(0, 1fr));
     gap: 6px;
     padding: 8px max(8px, env(safe-area-inset-left)) calc(8px + env(safe-area-inset-bottom)) max(8px, env(safe-area-inset-right));
     border-top: 1px solid var(--panel-border);

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -76,6 +76,19 @@ export interface ServerAnalytics {
   inviteJoins30d: number;
 }
 
+export interface ServerMemberSummary {
+  id: string;
+  userId: string;
+  role: UserRole;
+  createdAt: string;
+  updatedAt: string;
+  user: {
+    id: string;
+    username: string;
+    avatarUrl: string | null;
+  };
+}
+
 export interface ServerAuditLog {
   id: string;
   action: string;

--- a/web/tests/avatar-display.integration.test.tsx
+++ b/web/tests/avatar-display.integration.test.tsx
@@ -28,10 +28,15 @@ describe('avatar display integration', () => {
         unreadChannelCounts={{}}
         activeView="chat"
         onChangeView={vi.fn()}
+        scope="home"
+        scopeLabel="Home"
         onLogout={async () => {}}
         userId="user-1"
         username="max"
         isAdmin={false}
+        canManageScope={false}
+        canOpenServerView={false}
+        onOpenServerView={vi.fn()}
         onCreateChannel={async () => {}}
         onDeleteChannel={async () => {}}
         deletingChannelId={null}
@@ -50,6 +55,7 @@ describe('avatar display integration', () => {
         incomingFriendRequests={0}
         avatarUrl="/uploads/avatars/max.png"
         ping={42}
+        state="online"
       />,
     );
 

--- a/web/tests/server-management-panel.test.tsx
+++ b/web/tests/server-management-panel.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ServerManagementPanel } from '../src/components/server-management-panel';
+
+const server = {
+  id: 'server-1',
+  slug: 'alpha',
+  name: 'Alpha',
+  description: null,
+  iconUrl: null,
+  visibility: 'INVITE_ONLY' as const,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  owner: {
+    id: 'owner-1',
+    username: 'owner',
+    avatarUrl: null,
+  },
+  memberRole: 'OWNER' as const,
+  memberCount: 2,
+};
+
+describe('ServerManagementPanel', () => {
+  it('shows permission message for non-managers', () => {
+    render(
+      <ServerManagementPanel
+        server={server}
+        canManage={false}
+        loading={false}
+        error={null}
+        invites={[]}
+        analytics={null}
+        logs={[]}
+        members={[]}
+        moderationActions={[]}
+        inviteBusy={false}
+        moderationBusy={false}
+        onRefresh={async () => {}}
+        onCreateInvite={async () => {}}
+        onRevokeInvite={async () => {}}
+        onModerate={async () => {}}
+      />,
+    );
+
+    expect(
+      screen.getByText('You need moderator-level server role to access server management.'),
+    ).toBeInTheDocument();
+  });
+
+  it('submits invite and moderation actions', () => {
+    const onCreateInvite = vi.fn().mockResolvedValue(undefined);
+    const onModerate = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ServerManagementPanel
+        server={server}
+        canManage
+        loading={false}
+        error={null}
+        invites={[]}
+        analytics={{
+          memberCount: 2,
+          channelCount: 3,
+          messageCount24h: 4,
+          messageCount7d: 10,
+          activeMembers24h: 2,
+          moderationActions30d: 1,
+          inviteJoins30d: 1,
+        }}
+        logs={[]}
+        members={[
+          {
+            id: 'member-1',
+            userId: 'user-2',
+            role: 'MEMBER',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            user: {
+              id: 'user-2',
+              username: 'alice',
+              avatarUrl: null,
+            },
+          },
+        ]}
+        moderationActions={[]}
+        inviteBusy={false}
+        moderationBusy={false}
+        onRefresh={async () => {}}
+        onCreateInvite={onCreateInvite}
+        onRevokeInvite={async () => {}}
+        onModerate={onModerate}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Invite' }));
+    expect(onCreateInvite).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Target' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Action' }));
+    expect(onModerate).toHaveBeenCalledWith({
+      targetUserId: 'user-2',
+      type: 'WARN',
+      reason: undefined,
+      durationHours: undefined,
+    });
+  });
+});
+

--- a/web/tests/server-rail.test.tsx
+++ b/web/tests/server-rail.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ServerRail } from '../src/components/server-rail';
+
+describe('ServerRail', () => {
+  it('renders servers and triggers selection callbacks', () => {
+    const onSelectHome = vi.fn();
+    const onSelectServer = vi.fn();
+    const onCreateServer = vi.fn();
+    const onJoinServer = vi.fn();
+
+    render(
+      <ServerRail
+        servers={[
+          {
+            id: 'server-1',
+            slug: 'alpha',
+            name: 'Alpha Team',
+            description: null,
+            iconUrl: null,
+            visibility: 'INVITE_ONLY',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            owner: {
+              id: 'owner-1',
+              username: 'owner',
+              avatarUrl: null,
+            },
+            memberRole: 'OWNER',
+            memberCount: 3,
+          },
+        ]}
+        scope={{ kind: 'home' }}
+        onSelectHome={onSelectHome}
+        onSelectServer={onSelectServer}
+        onCreateServer={onCreateServer}
+        onJoinServer={onJoinServer}
+        creatingServer={false}
+        joiningServer={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Home' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Alpha Team' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create server' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Join server by invite' }));
+
+    expect(onSelectHome).toHaveBeenCalledTimes(1);
+    expect(onSelectServer).toHaveBeenCalledWith('server-1');
+    expect(onCreateServer).toHaveBeenCalledTimes(1);
+    expect(onJoinServer).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/web/tests/server-scope.test.ts
+++ b/web/tests/server-scope.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import type { Channel } from '../src/types/api';
+import {
+  filterChannelsForScope,
+  isChannelVisibleInScope,
+  isServerManagerRole,
+  pickFallbackChannelId,
+} from '../src/pages/chat/utils/server-scope';
+
+function makeChannel(input: Partial<Channel> & Pick<Channel, 'id' | 'name'>): Channel {
+  return {
+    id: input.id,
+    name: input.name,
+    createdAt: input.createdAt ?? '2026-01-01T00:00:00.000Z',
+    serverId: input.serverId ?? null,
+    isDirect: input.isDirect ?? false,
+    isVoice: input.isVoice ?? false,
+    voiceBitrateKbps: input.voiceBitrateKbps ?? null,
+    streamBitrateKbps: input.streamBitrateKbps ?? null,
+    directUser: input.directUser ?? null,
+  };
+}
+
+describe('server scope helpers', () => {
+  const channels: Channel[] = [
+    makeChannel({ id: 'dm-1', name: 'dm-a', isDirect: true }),
+    makeChannel({ id: 'dm-2', name: 'dm-b', isDirect: true }),
+    makeChannel({ id: 's1-text', name: 'general', serverId: 'server-1' }),
+    makeChannel({ id: 's1-voice', name: 'voice', serverId: 'server-1', isVoice: true }),
+    makeChannel({ id: 's2-text', name: 'general', serverId: 'server-2' }),
+  ];
+
+  it('filters home scope to direct channels only', () => {
+    const scoped = filterChannelsForScope(channels, { kind: 'home' });
+    expect(scoped.map((channel) => channel.id)).toEqual(['dm-1', 'dm-2']);
+  });
+
+  it('filters server scope to channels of selected server', () => {
+    const scoped = filterChannelsForScope(channels, { kind: 'server', serverId: 'server-1' });
+    expect(scoped.map((channel) => channel.id)).toEqual(['s1-text', 's1-voice']);
+  });
+
+  it('picks fallback channel id from current scope', () => {
+    expect(pickFallbackChannelId(channels, { kind: 'home' })).toBe('dm-1');
+    expect(pickFallbackChannelId(channels, { kind: 'server', serverId: 'server-2' })).toBe('s2-text');
+    expect(pickFallbackChannelId(channels, { kind: 'server', serverId: 'missing' })).toBeNull();
+  });
+
+  it('evaluates channel visibility within scope', () => {
+    const dmChannel = channels[0];
+    const serverChannel = channels[2];
+    expect(isChannelVisibleInScope(dmChannel, { kind: 'home' })).toBe(true);
+    expect(isChannelVisibleInScope(dmChannel, { kind: 'server', serverId: 'server-1' })).toBe(false);
+    expect(isChannelVisibleInScope(serverChannel, { kind: 'server', serverId: 'server-1' })).toBe(true);
+  });
+
+  it('detects server manager roles', () => {
+    expect(isServerManagerRole('OWNER')).toBe(true);
+    expect(isServerManagerRole('ADMIN')).toBe(true);
+    expect(isServerManagerRole('MODERATOR')).toBe(true);
+    expect(isServerManagerRole('MEMBER')).toBe(false);
+    expect(isServerManagerRole(null)).toBe(false);
+  });
+});
+


### PR DESCRIPTION
Expose server member listing and wire up server management UI.

- Backend: add ServerRepository.listMembers and Prisma implementation; add ServerService.listMembers and toMemberSummary; add GET /servers/:serverId/members route with auth and rate limiting; ensure new servers create default 'general' text and 'voice' voice channels when created.
- Tests: add route unit tests and extend ServerService tests to cover channel creation side effects and listMembers plumbing.
- Web: add chat-api.serverMembers, implement ServerManagementPanel and ServerRail components; extend ChannelSidebar and ChatPage to support home/server scopes, server rail interactions, server management flows, channel scoping, and member moderation/invite management; add related tests and types.

These changes enable server-scoped UI, server member management, and client/server flows for invites, moderation, and server lifecycle.